### PR TITLE
Issue 442: Templates as modes

### DIFF
--- a/Smooth Line View/SmoothLineView.h
+++ b/Smooth Line View/SmoothLineView.h
@@ -33,6 +33,7 @@
 @property (nonatomic, strong) UIColor *lineColor;
 @property (nonatomic, assign) CGFloat lineWidth;
 @property (nonatomic, assign) BOOL empty;
+@property (nonatomic) BOOL renderAsArea;
 
 -(void)clear;
 

--- a/Smooth Line View/SmoothLineView.m
+++ b/Smooth Line View/SmoothLineView.m
@@ -178,7 +178,8 @@ CGPoint midPoint(CGPoint p1, CGPoint p2) {
 
 - (BOOL) didChange
 {
-    return !self.path.isEmpty;
+    return !self.path.isEmpty
+        && (self.path.bounds.size.width > 0 || self.path.bounds.size.height > 0);
 }
 
 - (void) closeSubpath

--- a/Smooth Line View/SmoothLineView.m
+++ b/Smooth Line View/SmoothLineView.m
@@ -96,6 +96,14 @@ CGPoint midPoint(CGPoint p1, CGPoint p2);
   CGContextSetStrokeColorWithColor(context, self.lineColor.CGColor);
   
   CGContextStrokePath(context);
+    
+    if (self.renderAsArea)
+    {
+        CGContextAddPath(context, _path);
+        CGContextSetFillColorWithColor(context, [UIColor redColor].CGColor);
+        CGContextSetAlpha(context, 0.2);
+        CGContextFillPath(context);
+    }
   
   self.empty = NO;
 }


### PR DESCRIPTION
- Ability to render the current path as an area (filled)
- A change path is not empty and its bbox's width or height are not zero
